### PR TITLE
Fixed conditional jumps and added operator overload

### DIFF
--- a/ex02/include/Array.hpp
+++ b/ex02/include/Array.hpp
@@ -28,20 +28,20 @@ class Array
 		Array(): _size(0)
 		{
 			std::cout << "Default Constructor called: created empty Array of size 0" << std::endl;
-			this->_array = new T[this->_size];
+			this->_array = new T[this->size()];
 			// for (unsigned int i = 0; i < this->size(); i++)
 				// std::cout << this->_array << std::endl;
 		}
 
 		Array(unsigned int size): _size(size)
 		{
-			std::cout << "Constructor for an Array of size " << size << " called" << std::endl;
-			this->_array = new T[this->_size];
+			std::cout << "Constructor for an Array of size " << this->size() << " called" << std::endl;
+			this->_array = new T[this->size()]();
 			// for (unsigned int i = 0; i < this->size(); i++)
 			// 	std::cout << this->_array[i] << std::endl;
 		}
 
-		Array(const Array &src): _size(src.size())
+		Array(const Array &src)
 		{
 			std::cout << "Copy Constuctor called" << std::endl;
 			this->_array = NULL;
@@ -51,6 +51,7 @@ class Array
 	// Deconstructors
 		~Array()
 		{
+			std::cout << "Destructor called" << std::endl;
 			if (this->_array != NULL)
 				delete [] this->_array;
 		}
@@ -63,7 +64,7 @@ class Array
 			if (src.size() != 0)
 			{
 				this->_size = src.size();
-				this->_array = new T[this->_size];
+				this->_array = new T[this->size()];
 				for (unsigned int i = 0; i < this->size(); i++)
 					this->_array[i] = src._array[i];
 			}
@@ -72,7 +73,17 @@ class Array
 
 		T &operator[]( unsigned int index )
 		{
-			if (index >= this->_size || this->_array == NULL)
+			if (index >= this->size() || this->_array == NULL)
+			{
+				std::cout << "index: " << index << std::endl;
+				throw Array<T>::InvalidIndexException();
+			}
+			return (this->_array[index]);
+		}
+
+		const T &operator[]( unsigned int index ) const
+		{
+			if (index >= this->size() || this->_array == NULL)
 			{
 				std::cout << "index: " << index << std::endl;
 				throw Array<T>::InvalidIndexException();


### PR DESCRIPTION
- Added default initialization of array elements in constructor taking an unsigned int : 
`this->_array = new T[this->size()]();`
By adding parentheses at the end, the elements of the array are initialized by default, as requested in the subject. Moreover, this default initialization is essential, as failure to do so will result in a conditional jump when trying to access the array elements.

- Added destructor message, and used size() method to make the code fully coherent.

- Added [] operator overload for constant objects : 
`const T &operator[]( unsigned int index ) const`
The code must allow us to access and modify the array elements of non-constant objects, but also to access the array elements of a constant object without being able to modify them. To do this, we need 2 overloads of the [] operator (one for non-constant objects, and one for constant objects).

- Removed _size(src.size()) in copy constructor : 
The copy constructor calls the assignment operator, which itself contains a line for copying the value of the _size attribute. Moreover, there's a condition in the assignment operator that says to copy this value only if it's not equal to 0. However, if you initialize _size directly in the copy constructor with the _size value of the src object, before calling the assignment operator, and the value copied into _size is equal to 0, you're doing something you wanted to prevent by putting the condition present in the assignment operator.